### PR TITLE
Introduce Prompt customization into config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,12 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
   // "overrides": [
   //   {

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ You will be prompted to enter the name of your project, GitHub url, and select w
 
 **Note:** Do not skip entering these values or indexing may not work.
 
+**Prompt Configuration:** You'll find prompt directions specified in `prompts.ts`, with some snippets customizable in the `autodoc.config.json`. The current prompts are developer focused and assume your repo is code focused. We will have more reference templates in the future.
+
 Run the `index` command:
 ```bash
 doc index

--- a/autodoc.config.json
+++ b/autodoc.config.json
@@ -20,5 +20,10 @@
     "*.mdx",
     "*.toml",
     "*autodoc*"
-  ]
+  ],
+  "filePrompt": "Write a detailed technical explanation of what this code does. \n      Focus on the high-level purpose of the code and how it may be used in the larger project.\n      Include code examples where appropriate. Keep you response between 100 and 300 words. \n      DO NOT RETURN MORE THAN 300 WORDS.\n      Output should be in markdown format.\n      Do not just list the methods and classes in this file.",
+  "folderPrompt": "Write a technical explanation of what the code in this file does\n      and how it might fit into the larger project or work with other parts of the project.\n      Give examples of how this code might be used. Include code examples where appropriate.\n      Be concise. Include any information that may be relevant to a developer who is curious about this code.\n      Keep you response under 400 words. Output should be in markdown format.\n      Do not just list the files and folders in this folder.",
+  "chatPrompt": "",
+  "contentType": "code",
+  "targetAudience": "smart developer"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@context-labs/autodoc",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@context-labs/autodoc",
-      "version": "0.0.1",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@dqbd/tiktoken": "^1.0.2",
+        "@types/istextorbinary": "^2.3.1",
         "chalk": "^5.2.0",
         "cli-progress": "^3.12.0",
         "commander": "^10.0.0",
@@ -696,6 +697,14 @@
         "rxjs": "^7.2.0"
       }
     },
+    "node_modules/@types/istextorbinary": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/istextorbinary/-/istextorbinary-2.3.1.tgz",
+      "integrity": "sha512-Fu3zxViCkMd2oEkwQ1ITv16MCfybykq1VYjoeqLcYjeq3RhWDnwMb+Ang0MP3xwq17kDkCt8XQ7omTJ/1ukSoQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -783,8 +792,7 @@
     "node_modules/@types/node": {
       "version": "18.15.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.6.tgz",
-      "integrity": "sha512-YErOafCZpK4g+Rp3Q/PBgZNAsWKGunQTm9FA3/Pbcm0VCriTEzcrutQ/SxSc0rytAp0NoFWue669jmKhEtd0sA==",
-      "dev": true
+      "integrity": "sha512-YErOafCZpK4g+Rp3Q/PBgZNAsWKGunQTm9FA3/Pbcm0VCriTEzcrutQ/SxSc0rytAp0NoFWue669jmKhEtd0sA=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -5746,6 +5754,14 @@
         "rxjs": "^7.2.0"
       }
     },
+    "@types/istextorbinary": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/istextorbinary/-/istextorbinary-2.3.1.tgz",
+      "integrity": "sha512-Fu3zxViCkMd2oEkwQ1ITv16MCfybykq1VYjoeqLcYjeq3RhWDnwMb+Ang0MP3xwq17kDkCt8XQ7omTJ/1ukSoQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -5826,8 +5842,7 @@
     "@types/node": {
       "version": "18.15.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.6.tgz",
-      "integrity": "sha512-YErOafCZpK4g+Rp3Q/PBgZNAsWKGunQTm9FA3/Pbcm0VCriTEzcrutQ/SxSc0rytAp0NoFWue669jmKhEtd0sA==",
-      "dev": true
+      "integrity": "sha512-YErOafCZpK4g+Rp3Q/PBgZNAsWKGunQTm9FA3/Pbcm0VCriTEzcrutQ/SxSc0rytAp0NoFWue669jmKhEtd0sA=="
     },
     "@types/semver": {
       "version": "7.3.13",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.2",
+    "@types/istextorbinary": "^2.3.1",
     "chalk": "^5.2.0",
     "cli-progress": "^3.12.0",
     "commander": "^10.0.0",

--- a/src/cli/commands/estimate/index.ts
+++ b/src/cli/commands/estimate/index.ts
@@ -15,6 +15,11 @@ export const estimate = async ({
   output,
   llms,
   ignore,
+  filePrompt,
+  folderPrompt,
+  chatPrompt,
+  contentType,
+  targetAudience
 }: AutodocRepoConfig) => {
   const json = path.join(output, 'docs', 'json/');
 
@@ -32,6 +37,11 @@ export const estimate = async ({
       output: json,
       llms,
       ignore,
+      filePrompt,
+      folderPrompt,
+      chatPrompt,
+      contentType,
+      targetAudience
     },
     true,
   );

--- a/src/cli/commands/index/convertJsonToMarkdown.ts
+++ b/src/cli/commands/index/convertJsonToMarkdown.ts
@@ -14,6 +14,10 @@ export const convertJsonToMarkdown = async ({
   name: projectName,
   root: inputRoot,
   output: outputRoot,
+  filePrompt: filePrompt,
+  folderPrompt: folderPrompt,
+  contentType: contentType,
+  targetAudience: targetAudience
 }: AutodocRepoConfig) => {
   /**
    * Count the number of files in the project
@@ -27,6 +31,10 @@ export const convertJsonToMarkdown = async ({
       return Promise.resolve();
     },
     ignore: [],
+    filePrompt,
+    folderPrompt,
+    contentType,
+    targetAudience
   });
 
   /**
@@ -83,6 +91,10 @@ export const convertJsonToMarkdown = async ({
     projectName,
     processFile,
     ignore: [],
+    filePrompt,
+    folderPrompt,
+    contentType,
+    targetAudience
   });
   spinnerSuccess(`Created ${files} mardown files...`);
 };

--- a/src/cli/commands/index/convertJsonToMarkdown.ts
+++ b/src/cli/commands/index/convertJsonToMarkdown.ts
@@ -17,7 +17,7 @@ export const convertJsonToMarkdown = async ({
   filePrompt: filePrompt,
   folderPrompt: folderPrompt,
   contentType: contentType,
-  targetAudience: targetAudience
+  targetAudience: targetAudience,
 }: AutodocRepoConfig) => {
   /**
    * Count the number of files in the project
@@ -34,7 +34,7 @@ export const convertJsonToMarkdown = async ({
     filePrompt,
     folderPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
 
   /**
@@ -94,7 +94,7 @@ export const convertJsonToMarkdown = async ({
     filePrompt,
     folderPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   spinnerSuccess(`Created ${files} mardown files...`);
 };

--- a/src/cli/commands/index/index.ts
+++ b/src/cli/commands/index/index.ts
@@ -12,6 +12,11 @@ export const index = async ({
   output,
   llms,
   ignore,
+  filePrompt,
+  folderPrompt,
+  chatPrompt,
+  contentType,
+  targetAudience
 }: AutodocRepoConfig) => {
   const json = path.join(output, 'docs', 'json/');
   const markdown = path.join(output, 'docs', 'markdown/');
@@ -30,6 +35,11 @@ export const index = async ({
     output: json,
     llms,
     ignore,
+    filePrompt,
+    folderPrompt,
+    chatPrompt,
+    contentType,
+    targetAudience
   });
   updateSpinnerText('Processing repository...');
   spinnerSuccess();
@@ -45,6 +55,11 @@ export const index = async ({
     output: markdown,
     llms,
     ignore,
+    filePrompt,
+    folderPrompt,
+    chatPrompt,
+    contentType,
+    targetAudience
   });
   spinnerSuccess();
 
@@ -56,6 +71,11 @@ export const index = async ({
     output: data,
     llms,
     ignore,
+    filePrompt,
+    folderPrompt,
+    chatPrompt,
+    contentType,
+    targetAudience
   });
   spinnerSuccess();
 };

--- a/src/cli/commands/index/index.ts
+++ b/src/cli/commands/index/index.ts
@@ -16,7 +16,7 @@ export const index = async ({
   folderPrompt,
   chatPrompt,
   contentType,
-  targetAudience
+  targetAudience,
 }: AutodocRepoConfig) => {
   const json = path.join(output, 'docs', 'json/');
   const markdown = path.join(output, 'docs', 'markdown/');
@@ -39,7 +39,7 @@ export const index = async ({
     folderPrompt,
     chatPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   updateSpinnerText('Processing repository...');
   spinnerSuccess();
@@ -59,7 +59,7 @@ export const index = async ({
     folderPrompt,
     chatPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   spinnerSuccess();
 
@@ -75,7 +75,7 @@ export const index = async ({
     folderPrompt,
     chatPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   spinnerSuccess();
 };

--- a/src/cli/commands/index/processRepository.ts
+++ b/src/cli/commands/index/processRepository.ts
@@ -38,6 +38,11 @@ export const processRepository = async (
     output: outputRoot,
     llms,
     ignore,
+    filePrompt,
+    folderPrompt,
+    chatPrompt,
+    contentType,
+    targetAudience
   }: AutodocRepoConfig,
   dryRun?: boolean,
 ) => {
@@ -58,6 +63,9 @@ export const processRepository = async (
     fileName,
     filePath,
     projectName,
+    contentType,
+    filePrompt,
+    targetAudience
   }): Promise<void> => {
     const content = await fs.readFile(filePath, 'utf-8');
     const markdownFilePath = path.join(outputRoot, filePath);
@@ -66,11 +74,15 @@ export const processRepository = async (
       projectName,
       projectName,
       content,
+      contentType,
+      filePrompt
     );
     const questionsPrompt = createCodeQuestions(
       projectName,
       projectName,
       content,
+      contentType,
+      targetAudience
     );
     const summaryLength = encoding.encode(summaryPrompt).length;
     const questionLength = encoding.encode(questionsPrompt).length;
@@ -167,6 +179,8 @@ export const processRepository = async (
     folderName,
     folderPath,
     projectName,
+    contentType,
+    folderPrompt,
     shouldIgnore,
   }): Promise<void> => {
     /**
@@ -223,7 +237,7 @@ export const processRepository = async (
       );
 
       const summary = await callLLM(
-        folderSummaryPrompt(folderPath, projectName, files, folders),
+        folderSummaryPrompt(folderPath, projectName, files, folders, contentType, folderPrompt),
         models[LLMModels.GPT4].llm,
       );
 
@@ -252,7 +266,7 @@ export const processRepository = async (
   };
 
   /**
-   * Get the numver of files and folderfs in the project
+   * Get the number of files and folders in the project
    */
 
   const filesAndFolders = async (): Promise<{
@@ -271,6 +285,10 @@ export const processRepository = async (
           return Promise.resolve();
         },
         ignore,
+        filePrompt,
+        folderPrompt,
+        contentType,
+        targetAudience
       }),
       traverseFileSystem({
         inputPath: inputRoot,
@@ -280,6 +298,10 @@ export const processRepository = async (
           return Promise.resolve();
         },
         ignore,
+        filePrompt,
+        folderPrompt,
+        contentType,
+        targetAudience
       }),
     ]);
 
@@ -301,6 +323,10 @@ export const processRepository = async (
     projectName,
     processFile,
     ignore,
+    filePrompt,
+    folderPrompt,
+    contentType,
+    targetAudience
   });
   spinnerSuccess(`Processing ${files} files...`);
 
@@ -313,6 +339,10 @@ export const processRepository = async (
     projectName,
     processFolder,
     ignore,
+    filePrompt,
+    folderPrompt,
+    contentType,
+    targetAudience
   });
   spinnerSuccess(`Processing ${folders} folders... `);
   stopSpinner();

--- a/src/cli/commands/index/processRepository.ts
+++ b/src/cli/commands/index/processRepository.ts
@@ -40,9 +40,8 @@ export const processRepository = async (
     ignore,
     filePrompt,
     folderPrompt,
-    chatPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   }: AutodocRepoConfig,
   dryRun?: boolean,
 ) => {
@@ -65,7 +64,7 @@ export const processRepository = async (
     projectName,
     contentType,
     filePrompt,
-    targetAudience
+    targetAudience,
   }): Promise<void> => {
     const content = await fs.readFile(filePath, 'utf-8');
     const markdownFilePath = path.join(outputRoot, filePath);
@@ -75,14 +74,14 @@ export const processRepository = async (
       projectName,
       content,
       contentType,
-      filePrompt
+      filePrompt,
     );
     const questionsPrompt = createCodeQuestions(
       projectName,
       projectName,
       content,
       contentType,
-      targetAudience
+      targetAudience,
     );
     const summaryLength = encoding.encode(summaryPrompt).length;
     const questionLength = encoding.encode(questionsPrompt).length;
@@ -237,7 +236,14 @@ export const processRepository = async (
       );
 
       const summary = await callLLM(
-        folderSummaryPrompt(folderPath, projectName, files, folders, contentType, folderPrompt),
+        folderSummaryPrompt(
+          folderPath,
+          projectName,
+          files,
+          folders,
+          contentType,
+          folderPrompt,
+        ),
         models[LLMModels.GPT4].llm,
       );
 
@@ -288,7 +294,7 @@ export const processRepository = async (
         filePrompt,
         folderPrompt,
         contentType,
-        targetAudience
+        targetAudience,
       }),
       traverseFileSystem({
         inputPath: inputRoot,
@@ -301,7 +307,7 @@ export const processRepository = async (
         filePrompt,
         folderPrompt,
         contentType,
-        targetAudience
+        targetAudience,
       }),
     ]);
 
@@ -326,7 +332,7 @@ export const processRepository = async (
     filePrompt,
     folderPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   spinnerSuccess(`Processing ${files} files...`);
 
@@ -342,7 +348,7 @@ export const processRepository = async (
     filePrompt,
     folderPrompt,
     contentType,
-    targetAudience
+    targetAudience,
   });
   spinnerSuccess(`Processing ${folders} folders... `);
   stopSpinner();

--- a/src/cli/commands/index/prompts.ts
+++ b/src/cli/commands/index/prompts.ts
@@ -5,7 +5,7 @@ export const createCodeFileSummary = (
   projectName: string,
   fileContents: string,
   contentType: string,
-  filePrompt: string
+  filePrompt: string,
 ): string => {
   return `
     You are acting as a ${contentType} documentation expert for a project called ${projectName}.
@@ -26,7 +26,7 @@ export const createCodeQuestions = (
   projectName: string,
   fileContents: string,
   contentType: string,
-  targetAudience: string
+  targetAudience: string,
 ): string => {
   return `
     You are acting as a ${contentType} documentation expert for a project called ${projectName}.
@@ -48,7 +48,7 @@ export const folderSummaryPrompt = (
   files: FileSummary[],
   folders: FolderSummary[],
   contentType: string,
-  folderPrompt: string
+  folderPrompt: string,
 ): string => {
   return `
     You are acting as a ${contentType} documentation expert for a project called ${projectName}.

--- a/src/cli/commands/index/prompts.ts
+++ b/src/cli/commands/index/prompts.ts
@@ -4,19 +4,16 @@ export const createCodeFileSummary = (
   filePath: string,
   projectName: string,
   fileContents: string,
+  contentType: string,
+  filePrompt: string
 ): string => {
   return `
-    You are acting as a code documentation expert for a project called ${projectName}.
-    Below is the code from a file located at \`${filePath}\`. 
-    Write a detailed technical explanation of what this code does. 
-    Focus on the high-level purpose of the code and how it may be used in the larger project.
-    Include code examples where appropriate. Keep you response between 100 and 300 words. 
-    DO NOT RETURN MORE THAN 300 WORDS.
-    Output should be in markdown format. 
+    You are acting as a ${contentType} documentation expert for a project called ${projectName}.
+    Below is the ${contentType} from a file located at \`${filePath}\`. 
+    ${filePrompt}
     Do not say "this file is a part of the ${projectName} project".
-    Do not just list the methods and classes in this file.
 
-    Code:
+    ${contentType}:
     ${fileContents}
 
     Response:
@@ -28,14 +25,16 @@ export const createCodeQuestions = (
   filePath: string,
   projectName: string,
   fileContents: string,
+  contentType: string,
+  targetAudience: string
 ): string => {
   return `
-    You are acting as a code documentation expert for a project called ${projectName}.
-    Below is the code from a file located at \`${filePath}\`. 
-    What are 3 questions that a super smart developer might have about this code? 
+    You are acting as a ${contentType} documentation expert for a project called ${projectName}.
+    Below is the ${contentType} from a file located at \`${filePath}\`. 
+    What are 3 questions that a ${targetAudience} might have about this code? 
     Answer each question in 1-2 sentences. Output should be in markdown format.
 
-    Code:
+    ${contentType}:
     ${fileContents}
 
     Questions and Answers:
@@ -48,9 +47,11 @@ export const folderSummaryPrompt = (
   projectName: string,
   files: FileSummary[],
   folders: FolderSummary[],
+  contentType: string,
+  folderPrompt: string
 ): string => {
   return `
-    You are acting as a code documentation expert for a project called ${projectName}.
+    You are acting as a ${contentType} documentation expert for a project called ${projectName}.
     You are currently documenting the folder located at \`${folderPath}\`. 
     
     Below is a list of the files in this folder and a summary of the contents of each file:
@@ -73,15 +74,8 @@ export const folderSummaryPrompt = (
       `;
     })}
 
-
-    Write a technical explanation of what the code in this file does
-    and how it might fit into the larger project or work with other parts of the project.
-    Give examples of how this code might be used. Include code examples where appropriate.
-    Be concise. Include any information that may be relevant to a developer who is curious about this code.
-    Keep you response under 400 words. Output should be in markdown format.
+    ${folderPrompt}
     Do not say "this file is a part of the ${projectName} project".
-    Do not just list the files and folders in this folder.
-
 
     Response:
   `;

--- a/src/cli/commands/init/index.ts
+++ b/src/cli/commands/init/index.ts
@@ -30,21 +30,23 @@ export const makeConfigTemplate = (
       '*.toml',
       '*autodoc*',
     ],
-    filePrompt: "Write a detailed technical explanation of what this code does. \
-                Focus on the high-level purpose of the code and how it may be used in the larger project.\
-                Include code examples where appropriate. Keep you response between 100 and 300 words. \
-                DO NOT RETURN MORE THAN 300 WORDS.\
-                Output should be in markdown format.\
-                Do not just list the methods and classes in this file.",
-    folderPrompt: "Write a technical explanation of what the code in this file does\
-              and how it might fit into the larger project or work with other parts of the project.\
-              Give examples of how this code might be used. Include code examples where appropriate.\
-              Be concise. Include any information that may be relevant to a developer who is curious about this code.\
-              Keep you response under 400 words. Output should be in markdown format.\
-              Do not just list the files and folders in this folder.",
-    chatPrompt: "",
-    contentType: "code",
-    targetAudience: "smart developer",
+    filePrompt:
+      'Write a detailed technical explanation of what this code does. \
+      Focus on the high-level purpose of the code and how it may be used in the larger project.\
+      Include code examples where appropriate. Keep you response between 100 and 300 words. \
+      DO NOT RETURN MORE THAN 300 WORDS.\
+      Output should be in markdown format.\
+      Do not just list the methods and classes in this file.',
+    folderPrompt:
+      'Write a technical explanation of what the code in this file does\
+      and how it might fit into the larger project or work with other parts of the project.\
+      Give examples of how this code might be used. Include code examples where appropriate.\
+      Be concise. Include any information that may be relevant to a developer who is curious about this code.\
+      Keep you response under 400 words. Output should be in markdown format.\
+      Do not just list the files and folders in this folder.',
+    chatPrompt: '',
+    contentType: 'code',
+    targetAudience: 'smart developer',
   };
 };
 

--- a/src/cli/commands/init/index.ts
+++ b/src/cli/commands/init/index.ts
@@ -30,6 +30,21 @@ export const makeConfigTemplate = (
       '*.toml',
       '*autodoc*',
     ],
+    filePrompt: "Write a detailed technical explanation of what this code does. \
+                Focus on the high-level purpose of the code and how it may be used in the larger project.\
+                Include code examples where appropriate. Keep you response between 100 and 300 words. \
+                DO NOT RETURN MORE THAN 300 WORDS.\
+                Output should be in markdown format.\
+                Do not just list the methods and classes in this file.",
+    folderPrompt: "Write a technical explanation of what the code in this file does\
+              and how it might fit into the larger project or work with other parts of the project.\
+              Give examples of how this code might be used. Include code examples where appropriate.\
+              Be concise. Include any information that may be relevant to a developer who is curious about this code.\
+              Keep you response under 400 words. Output should be in markdown format.\
+              Do not just list the files and folders in this folder.",
+    chatPrompt: "",
+    contentType: "code",
+    targetAudience: "smart developer",
   };
 };
 

--- a/src/cli/commands/init/index.ts
+++ b/src/cli/commands/init/index.ts
@@ -31,18 +31,18 @@ export const makeConfigTemplate = (
       '*autodoc*',
     ],
     filePrompt:
-      'Write a detailed technical explanation of what this code does. \
-      Focus on the high-level purpose of the code and how it may be used in the larger project.\
-      Include code examples where appropriate. Keep you response between 100 and 300 words. \
-      DO NOT RETURN MORE THAN 300 WORDS.\
-      Output should be in markdown format.\
+      'Write a detailed technical explanation of what this code does. \n\
+      Focus on the high-level purpose of the code and how it may be used in the larger project.\n\
+      Include code examples where appropriate. Keep you response between 100 and 300 words. \n\
+      DO NOT RETURN MORE THAN 300 WORDS.\n\
+      Output should be in markdown format.\n\
       Do not just list the methods and classes in this file.',
     folderPrompt:
-      'Write a technical explanation of what the code in this file does\
-      and how it might fit into the larger project or work with other parts of the project.\
-      Give examples of how this code might be used. Include code examples where appropriate.\
-      Be concise. Include any information that may be relevant to a developer who is curious about this code.\
-      Keep you response under 400 words. Output should be in markdown format.\
+      'Write a technical explanation of what the code in this file does\n\
+      and how it might fit into the larger project or work with other parts of the project.\n\
+      Give examples of how this code might be used. Include code examples where appropriate.\n\
+      Be concise. Include any information that may be relevant to a developer who is curious about this code.\n\
+      Keep you response under 400 words. Output should be in markdown format.\n\
       Do not just list the files and folders in this folder.',
     chatPrompt: '',
     contentType: 'code',

--- a/src/cli/commands/query/createChatChain.ts
+++ b/src/cli/commands/query/createChatChain.ts
@@ -12,19 +12,20 @@ Chat History:
 Follow Up Input: {question}
 Standalone question:`);
 
-const makeQAPrompt = (projectName: string, repositoryUrl: string) =>
+const makeQAPrompt = (projectName: string, repositoryUrl: string, contentType: string, chatPrompt: string, targetAudience: string) =>
   PromptTemplate.fromTemplate(
-    `You are an AI assistant for a software project called ${projectName}. You are trained on all the code that makes up this project.
-  The code for the project is located at ${repositoryUrl}.
-You are given the following extracted parts of a technical summary of files in a codebase and a question. 
+    `You are an AI assistant for a software project called ${projectName}. You are trained on all the ${contentType} that makes up this project.
+  The ${contentType} for the project is located at ${repositoryUrl}.
+You are given the following extracted parts of a technical summary of files in a ${contentType} and a question. 
 Provide a conversational answer with hyperlinks back to GitHub.
 You should only use hyperlinks that are explicitly listed in the context. Do NOT make up a hyperlink that is not listed.
-Include lots of code examples and links to the code examples, where appropriate.
-Assume the reader is a technical person but is not deeply familiar with ${projectName}.
-Assume th reader does not know anything about how the project is strucuted or which folders/files are provided in the context.
+Include lots of ${contentType} examples and links to the ${contentType} examples, where appropriate.
+${chatPrompt}
+Assume the reader is a ${targetAudience} but is not deeply familiar with ${projectName}.
+Assume the reader does not know anything about how the project is strucuted or which folders/files are provided in the context.
 Do not reference the context in your answer. Instead use the context to inform your answer.
 If you don't know the answer, just say "Hmm, I'm not sure." Don't try to make up an answer.
-If the question is not about the ${projectName}, politely inform them that you are tuned to only answer questions about the Solana validator.
+If the question is not about the ${projectName}, politely inform them that you are tuned to only answer questions about the ${projectName}.
 Your answer should be at least 100 words and no more than 300 words.
 Do not include information that is not directly relevant to the question, even if the context includes it.
 Always include a list of reference links to GitHub from the context. Links should ONLY come from the context.
@@ -41,6 +42,9 @@ Answer in Markdown:`,
 export const makeChain = (
   projectName: string,
   repositoryUrl: string,
+  contentType: string,
+  chatPrompt: string,
+  targetAudience: string,
   vectorstore: HNSWLib,
   llms: LLMModels[],
   onTokenStream?: (token: string) => void,
@@ -54,7 +58,7 @@ export const makeChain = (
     prompt: CONDENSE_PROMPT,
   });
 
-  const QA_PROMPT = makeQAPrompt(projectName, repositoryUrl);
+  const QA_PROMPT = makeQAPrompt(projectName, repositoryUrl, contentType, chatPrompt, targetAudience);
   const docChain = loadQAChain(
     new OpenAIChat({
       temperature: 0.2,

--- a/src/cli/commands/query/index.ts
+++ b/src/cli/commands/query/index.ts
@@ -28,7 +28,7 @@ const clearScreenAndMoveCursorToTop = () => {
 };
 
 export const query = async (
-  { name, repositoryUrl, output }: AutodocRepoConfig,
+  { name, repositoryUrl, output, contentType, chatPrompt, targetAudience }: AutodocRepoConfig,
   { llms }: AutodocUserConfig,
 ) => {
   const data = path.join(output, 'docs', 'data/');
@@ -36,6 +36,9 @@ export const query = async (
   const chain = makeChain(
     name,
     repositoryUrl,
+    contentType,
+    chatPrompt,
+    targetAudience,
     vectorStore,
     llms,
     (token: string) => {

--- a/src/cli/utils/traverseFileSystem.ts
+++ b/src/cli/utils/traverseFileSystem.ts
@@ -8,7 +8,7 @@ export const traverseFileSystem = async (
   params: TraverseFileSystemParams,
 ): Promise<void> => {
   try {
-    const { inputPath, projectName, processFile, processFolder, ignore } =
+    const { inputPath, projectName, processFile, processFolder, ignore, filePrompt, folderPrompt, contentType, targetAudience } =
       params;
 
     try {
@@ -40,6 +40,9 @@ export const traverseFileSystem = async (
               folderPath,
               projectName,
               shouldIgnore,
+              folderPrompt,
+              contentType,
+              targetAudience
             });
           }
         }),
@@ -55,6 +58,9 @@ export const traverseFileSystem = async (
               fileName,
               filePath,
               projectName,
+              filePrompt,
+              contentType,
+              targetAudience
             });
           }
         }),

--- a/src/cli/utils/traverseFileSystem.ts
+++ b/src/cli/utils/traverseFileSystem.ts
@@ -8,8 +8,8 @@ export const traverseFileSystem = async (
   params: TraverseFileSystemParams,
 ): Promise<void> => {
   try {
-    const { inputPath, projectName, processFile, processFolder, ignore, filePrompt, folderPrompt, contentType, targetAudience } =
-      params;
+    // eslint-disable-next-line prettier/prettier
+    const { inputPath, projectName, processFile, processFolder, ignore, filePrompt, folderPrompt, contentType, targetAudience } = params;
 
     try {
       await fs.access(inputPath);
@@ -42,7 +42,7 @@ export const traverseFileSystem = async (
               shouldIgnore,
               folderPrompt,
               contentType,
-              targetAudience
+              targetAudience,
             });
           }
         }),
@@ -60,7 +60,7 @@ export const traverseFileSystem = async (
               projectName,
               filePrompt,
               contentType,
-              targetAudience
+              targetAudience,
             });
           }
         }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,11 @@ export type AutodocRepoConfig = {
   output: string;
   llms: LLMModels[];
   ignore: string[];
+  filePrompt: string;
+  folderPrompt: string;
+  chatPrompt: string;
+  contentType: string;
+  targetAudience: string;
 };
 
 export type FileSummary = {
@@ -25,6 +30,9 @@ export type ProcessFileParams = {
   fileName: string;
   filePath: string;
   projectName: string;
+  contentType: string;
+  filePrompt: string;
+  targetAudience: string;
 };
 
 export type ProcessFile = (params: ProcessFileParams) => Promise<void>;
@@ -43,6 +51,9 @@ export type ProcessFolderParams = {
   folderName: string;
   folderPath: string;
   projectName: string;
+  contentType: string;
+  folderPrompt: string;
+  targetAudience: string;
   shouldIgnore: (fileName: string) => boolean;
 };
 
@@ -54,6 +65,10 @@ export type TraverseFileSystemParams = {
   processFile?: ProcessFile;
   processFolder?: ProcessFolder;
   ignore: string[];
+  filePrompt: string;
+  folderPrompt: string;
+  contentType: string;
+  targetAudience: string;
 };
 
 export enum LLMModels {


### PR DESCRIPTION
This PR adds `filePrompt`, `folderPrompt`, `chatPrompt`, `contentType`, and `targetAudience` into the config to make prompts more flexible. 

Ideally, in the future, you could choose some preset for `code`, `developer docs`, or other kinds of repositories. 

I've checked that the whole `doc init` and `doc index` process still works, and moved the original prompts into the default config.

I'm not super used to typescript so I may have made some antipatterns along the way 😅 

Super excited to see this tool grow further.