### PR TITLE
fix: pass buffer to isText()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-labs/autodoc",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "autodoc",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/utils/traverseFileSystem.ts
+++ b/src/cli/utils/traverseFileSystem.ts
@@ -54,7 +54,13 @@ export const traverseFileSystem = async (
           const filePath = path.join(currentPath, fileName);
           const entryStats = await fs.stat(filePath);
 
-          if (entryStats.isFile() && isText(fileName)) {
+          if (!entryStats.isFile()) {
+            return;
+          }
+
+          const buffer = await fs.readFile(filePath);
+
+          if (isText(fileName, buffer)) {
             await processFile?.({
               fileName,
               filePath,


### PR DESCRIPTION
`isText` with only the filename returns null for `.sol` files. The actual file content should be passed along with the file name to fix this.