### PR TITLE
Use `path.dirname` instead of wrong `string.lastIndexOf`

### DIFF
--- a/src/cli/commands/index/processRepository.ts
+++ b/src/cli/commands/index/processRepository.ts
@@ -81,7 +81,7 @@ export const processRepository = async (
      * it will check the checksums and decide if a reindex is needed
      */
     const reindex = await shouldReindex(
-      path.join(outputRoot, filePath.substring(0, filePath.lastIndexOf('\\'))),
+      path.join(outputRoot, path.dirname(filePath)),
       fileName.replace(/\.[^/.]+$/, '.json'),
       newChecksum,
     );


### PR DESCRIPTION
Passing `\\` to `lastIndexOf` ultimately passed an empty string to `shouldReindex` which caused `shouldReindex` to always return true.

Note: `\\` is the path delimiter on windows, maybe this worked on windows before, but it's not crossplatform. 